### PR TITLE
devcontainerのユーザー設定を動的に変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,12 @@
 {
     "name": "dot-devcontainer-golang-1.24",
     "image": "ghcr.io/bearfield/golang:1.24",
-    "containerEnv": {
-        "DEVCONTAINER_USER": "devuser"
-    },
-    "remoteUser": "${containerEnv:DEVCONTAINER_USER}",
+    "remoteUser": "${localEnv:USER}",
     "mounts": [
-        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${containerEnv:DEVCONTAINER_USER}/.gitconfig,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.config/gcloud,target=/home/${containerEnv:DEVCONTAINER_USER}/.config/gcloud,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/${containerEnv:DEVCONTAINER_USER}/.ssh,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.claude,target=/home/${containerEnv:DEVCONTAINER_USER}/.claude,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.config/gcloud,target=/home/${localEnv:USER}/.config/gcloud,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.claude,target=/home/${localEnv:USER}/.claude,type=bind,consistency=cached"
     ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,6 @@ The Dockerfile installs Go 1.24.3 with necessary build tools (gcc, g++, libc6-de
 ## Container Configuration
 
 - **GOPATH**: `/go`
-- **User**: `kumano_ryo`
+- **User**: `${localEnv:USER}` (dynamic based on host user)
 - **Shell**: fish (inherited from base image)
 - **Working Directory**: `$GOPATH`

--- a/README.md
+++ b/README.md
@@ -69,13 +69,16 @@ GitHub Actionsにより、以下のタイミングで自動ビルドとリリー
 
 - **GOPATH**: `/go`
 - **作業ディレクトリ**: `/go`
-- **ユーザー**: カスタマイズ可能（デフォルト: devuser）
+- **ユーザー**: 環境変数`${localEnv:USER}`で動的設定
 
-### カスタマイズ
+### VS Code Dev Container設定
 
-GitHub リポジトリの変数で以下をカスタマイズできます：
+以下のホスト環境設定がコンテナにマウントされます：
 
-- `CONTAINER_USER_NAME`: コンテナ内のユーザー名（デフォルト: devuser）
+- `~/.gitconfig` (Linux用設定)
+- `~/.config/gcloud` (Google Cloud CLI設定)
+- `~/.ssh` (SSH鍵)
+- `~/.claude` (Claude Code設定)
 
 ## 必要な設定
 


### PR DESCRIPTION
## Summary
- devcontainer.jsonでcontainerEnvを削除し、`${localEnv:USER}`を直接使用するよう修正
- マウントパスもホストユーザー名に基づいて動的に設定
- README.mdとCLAUDE.mdでユーザー設定の説明を更新

## Test plan
- [x] VS Code Remote Containerで正常に接続できることを確認
- [x] ホストユーザー名がコンテナ内で正しく反映されることを確認
- [x] マウントされた設定ファイルが正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)